### PR TITLE
update to the latest Dassets, use new `source_path` option

### DIFF
--- a/dassets-lessv1.gemspec
+++ b/dassets-lessv1.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   # lock in to the 1.x.x LESS ruby compiler b/c this is Lessv1
   # ie https://github.com/cloudhead/less/tree/v1.2.21
   gem.add_dependency("less", ["~> 1.1"])
-  gem.add_dependency("dassets")
+  gem.add_dependency("dassets", ["~> 0.6"])
 
 end

--- a/lib/dassets-lessv1.rb
+++ b/lib/dassets-lessv1.rb
@@ -11,19 +11,24 @@ module Dassets::Lessv1
     end
 
     def compile(input_content)
-      Source.new(input_content).to_css
+      compiler(input_content).to_css
+    end
+
+    def compiler(content)
+      Compiler.new(content, self.opts)
     end
 
   end
 
   # This is a little wrapper class to the less engine.  I use this to access
   # and set the `@path` instance variable on the engine.  This sets the root
-  # path all imports are done from.  This just makes importing partials easier.
+  # path all imports are done from to the path of the source the engine was
+  # registered on.  This allows you to import partials relative to the source.
 
-  class Source < ::Less::Engine
+  class Compiler < ::Less::Engine
     attr_reader :path
-    def initialize(content, opts={})
-      @path = Dassets.config.source_path
+    def initialize(content, opts)
+      @path = opts['source_path']
       super
     end
   end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -11,10 +11,19 @@ class Dassets::Lessv1::Engine
     end
     subject{ @engine }
 
+    should have_instance_method :compiler
+
     should "be a Dassets engine" do
       assert_kind_of Dassets::Engine, subject
       assert_respond_to 'ext', subject
       assert_respond_to 'compile', subject
+    end
+
+    should "use a Less compiler with the path set to the source path" do
+      c = subject.compiler('')
+      assert_kind_of ::Less::Engine, c
+      assert_respond_to :to_css, c
+      assert_equal subject.opts['source_path'], c.path
     end
 
     should "transform any input extension to `css`" do


### PR DESCRIPTION
This updates to require the latest Dassets and use the new default
`source_path` option to set the path imports are relative to.

@jcredding ready for review.
